### PR TITLE
Use proc-macro instead of compiler plugins.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,18 +31,22 @@
 //! - `named!(string)` takes a string and replaces any `\\N{name}`
 //!   sequences with the character with that name. NB. String escape
 //!   sequences cannot be customised, so the extra backslash (or a raw
-//!   string) is required.
+//!   string) is required, unless you use a raw string.
 //!
 //! ```rust
-//! #![feature(plugin)]
-//! #![plugin(unicode_names2_macros)]
-//! # extern crate unicode_names2; // pointless, just avoid extern crate being inserted
+//! #![feature(proc_macro_hygiene)]
+//!
+//! #[macro_use]
+//! extern crate unicode_names2_macros;
 //!
 //! fn main() {
 //!     let x: char = named_char!("snowman");
 //!     assert_eq!(x, '☃');
 //!
 //!     let y: &str = named!("foo bar \\N{BLACK STAR} baz qux");
+//!     assert_eq!(y, "foo bar ★ baz qux");
+//!
+//!     let y: &str = named!(r"foo bar \N{BLACK STAR} baz qux");
 //!     assert_eq!(y, "foo bar ★ baz qux");
 //! }
 //! ```
@@ -218,7 +222,6 @@ impl fmt::Display for Name {
 /// # Example
 ///
 /// ```rust
-/// # #![allow(unstable)]
 /// assert_eq!(unicode_names2::name('a').map(|n| n.to_string()),
 ///            Some("LATIN SMALL LETTER A".to_string()));
 /// assert_eq!(unicode_names2::name('\u{2605}').map(|n| n.to_string()),

--- a/unicode_names2_macros/Cargo.toml
+++ b/unicode_names2_macros/Cargo.toml
@@ -9,14 +9,16 @@ homepage = "https://github.com/ProgVal/unicode_names2"
 repository = "https://github.com/ProgVal/unicode_names2"
 documentation = "https://docs.rs/unicode_names2/"
 license = "MIT/Apache-2.0"
-keywords = ["text", "unicode", "plugin"]
+keywords = ["text", "unicode", "macro"]
 description = "Support macros for `unicode_names2`."
 
 [features]
+
 unstable = []
 
 [dependencies]
 regex = "0.1.80"
+syn = "0.15"
 
 [dependencies.unicode_names2]
 path = ".."
@@ -24,4 +26,4 @@ version = "0.3.0"
 
 [lib]
 name = "unicode_names2_macros"
-plugin = true
+proc-macro = true

--- a/unicode_names2_macros/tests/test.rs
+++ b/unicode_names2_macros/tests/test.rs
@@ -1,5 +1,7 @@
-#![feature(plugin)]
-#![plugin(unicode_names2_macros)]
+#![feature(proc_macro_hygiene)]
+
+#[macro_use]
+extern crate unicode_names2_macros;
 
 #[test]
 fn named_char() {
@@ -11,4 +13,6 @@ fn named_char() {
 fn named() {
     assert_eq!(named!("123\\N{latin small letter a}456"), "123a456");
     assert_eq!(named!("123\\N{SNOWMAN}\\N{BLACK STAR}456"), "123☃★456");
+    assert_eq!(named!(r"123\N{latin small letter a}456"), "123a456");
+    assert_eq!(named!(r"123\N{SNOWMAN}\N{BLACK STAR}456"), "123☃★456");
 }


### PR DESCRIPTION
I think it's cleaner, and `proc_macro_hygiene` is more likely to be stabilized soon than compiler plugins.
On the other hand, it adds a dependency on `syn`, which is a non-trivial crate...

@antifuchs I'm guessing you don't use these macros, but would you like to take a look at this?