### PR TITLE
ci: Bump rustc from 1.48 to 1.63

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         rust:
         - stable
         - beta
-        - 1.48.0
+        - 1.63.0
 
         features:
         - ''


### PR DESCRIPTION
The 'log' crate depends on cfg(target_has_atomic) now