### PR TITLE
Fix i686 host builds

### DIFF
--- a/generator/src/util.rs
+++ b/generator/src/util.rs
@@ -1,14 +1,19 @@
-pub fn smallest_index(n: usize) -> usize {
-    for &x in [8, 16, 32].iter() {
-        if n < (1 << x) {
-            return x / 8;
+/// Figure out whether we need `u8` (1 byte), `u16` (2 bytes) or `u32` (4 bytes) to store all
+/// numbers. Returns the number of bytes
+pub fn smallest_type<I: Iterator<Item = u32>>(x: I) -> usize {
+    assert!(
+        usize::BITS >= u32::BITS,
+        "Architectures with less than 32 bit `usize`s are not supported"
+    );
+    let n = x.max().unwrap_or(0);
+    for (max, bytes) in [(u8::MAX as u32, 1), (u16::MAX as u32, 2)] {
+        if n <= max {
+            return bytes;
         }
     }
-    64
+    4
 }
-pub fn smallest_type<I: Iterator<Item = u32>>(x: I) -> usize {
-    smallest_index(x.max().unwrap_or(0) as usize)
-}
+
 pub fn smallest_u<I: Iterator<Item = u32>>(x: I) -> String {
     format!("u{}", 8 * smallest_type(x))
 }

--- a/generator/src/util.rs
+++ b/generator/src/util.rs
@@ -1,10 +1,6 @@
 /// Figure out whether we need `u8` (1 byte), `u16` (2 bytes) or `u32` (4 bytes) to store all
 /// numbers. Returns the number of bytes
 pub fn smallest_type<I: Iterator<Item = u32>>(x: I) -> usize {
-    assert!(
-        usize::BITS >= u32::BITS,
-        "Architectures with less than 32 bit `usize`s are not supported"
-    );
     let n = x.max().unwrap_or(0);
     for (max, bytes) in [(u8::MAX as u32, 1), (u16::MAX as u32, 2)] {
         if n <= max {


### PR DESCRIPTION
In the generator, we have
```rust
pub fn smallest_index(n: usize) -> usize {
    for &x in [8, 16, 32].iter() {
        if n < (1 << x) {
            return x / 8;
        }
    }
    64
}
```
where `x` is inferred to be `usize`. When the host architecture is 32-bits, `(1 << x)` overflows. For release build, this doesn't crash but leads to strange invalid generated.rs which contain an undefined `u512` type (https://github.com/astral-sh/ruff/actions/runs/6500014395/job/17659540717). Note that the crash only happens on i686 hosts (i used the quay.io/pypa/manylinux2014_i686 docker container), if you're cross compiling build scripts are compiled to the host architecture and the build works fine.

This change fixes this by instead pinning types to 4 bytes max, which seems sufficient. I only changed this specific `usize` that unbreaks the build, but there are more `usize` usages in the generator that might be problematic that i haven't checked.