### PR TITLE
Make dependency on 'time' optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         - nightly
 
         features:
-        - ''
+        - '--all-features'
         - '--no-default-features'
 
     steps:
@@ -96,13 +96,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           profile: minimal
           override: true
-
-      - name: downgrade 'time' for Rust 1.63.0
-        uses: actions-rs/cargo@v1
-        with:
-          command: update
-          args: --package time --precise 0.3.20
-        if: ${{ matrix.rust == '1.63.0' }}
 
       - name: Build generator
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ default = []
 
 unstable = []
 no_std = []
+generator-timing = ["unicode_names2_generator/timing"]
 
 [dev-dependencies.unicode_names2_macros]
 path = "unicode_names2_macros"

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -15,9 +15,11 @@ Generates the perfect-hash function used by `unicode_names2`.
 
 [features]
 unstable = []
+default = []
+timing = ["time"]
 
 [dependencies]
-time = "0.3,<0.3.21"
+time = { version = "0.3", optional = true }
 log = "0"
 getopts = "0.2.21"
 rand = "0.8.5"

--- a/generator/src/phf.rs
+++ b/generator/src/phf.rs
@@ -145,14 +145,20 @@ pub fn create_phf(
     max_tries: usize,
 ) -> (u64, Vec<(u32, u32)>, Vec<char>) {
     let mut rng = StdRng::seed_from_u64(0xf0f0f0f0);
+    #[cfg(feature = "timing")]
     let start = time::Instant::now();
 
     for i in 0..(max_tries) {
+        #[cfg(feature = "timing")]
         let my_start = time::Instant::now();
+        #[cfg(feature = "timing")]
         println!("PHF #{}: starting {:.2}", i, my_start - start);
+        #[cfg(not(feature = "timing"))]
+        println!("PHF #{}", i);
 
         let seed = rng.gen();
         if let Some((disp, map)) = try_phf_table(data, lambda, seed, &mut rng) {
+            #[cfg(feature = "timing")]
             println!(
                 "PHF took: total {:.2} s, successive {:.2} s",
                 start.elapsed(),


### PR DESCRIPTION
Resolves the issue of needing an upper-bound on its version in order to support Rust 1.63: https://github.com/progval/unicode_names2/issues/36