### PR TITLE
Address more Clippy warnings

### DIFF
--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -14,11 +14,8 @@ Generates the perfect-hash function used by `unicode_names2`.
 """
 
 [features]
-unstable = []
-default = []
-timing = ["time"]
+timing = []
 
 [dependencies]
-time = { version = "0.3", optional = true }
 rand = "0.8.5"
 phf_codegen = "0.11.1"

--- a/generator/src/formatting.rs
+++ b/generator/src/formatting.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, io::prelude::*};
 
-static LINE_LIMIT: usize = 95;
+const LINE_LIMIT: usize = 95;
 
 pub struct Context {
     pub out: Box<dyn Write + 'static>,

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -119,9 +119,8 @@ fn write_cjk_ideograph_ranges(ctxt: &mut Context, ranges: &[(char, char)]) {
     ctxt.write_debugs("CJK_IDEOGRAPH_RANGES", "(char, char)", ranges)
 }
 
-/// Construct a huge string storing the text data, and return it,
-/// along with information about the position and frequency of the
-/// constituent words of the input.
+/// Construct a huge string storing the text data, and return it, along with information about the
+/// position and frequency of the constituent words of the input.
 fn create_lexicon_and_offsets(
     mut codepoint_names: Vec<(char, &str)>,
 ) -> (String, Vec<(usize, Vec<u8>, usize)>) {

--- a/generator/src/phf.rs
+++ b/generator/src/phf.rs
@@ -1,12 +1,12 @@
-//! Computes a perfect hash table using [the CHD
-//! algorithm](http://cmph.sourceforge.net/papers/esa09.pdf).
+//! Computes a perfect hash table using
+//! [the CHD algorithm](http://cmph.sourceforge.net/papers/esa09.pdf).
 //!
-//! Strongly inspired by https://github.com/sfackler/rust-phf
+//! Strongly inspired by [rust-phf](https://github.com/sfackler/rust-phf).
 
 use rand::prelude::{Rng, SeedableRng, SliceRandom, StdRng};
 use std::iter::repeat;
 
-static NOVAL: char = '\0';
+const NO_VAL: char = '\0';
 
 /// FNV
 fn hash(s: &str, h: u64) -> u64 {
@@ -67,7 +67,7 @@ fn try_phf_table(
     // value for `foo` is "just" `map[displace(hash(foo))]`, where
     // `displace` uses the pair of displacements that we computed
     // (stored in `disps`).
-    let mut map = repeat(NOVAL).take(table_len).collect::<Vec<_>>();
+    let mut map = repeat(NO_VAL).take(table_len).collect::<Vec<_>>();
     let mut disps = repeat((0, 0)).take(buckets_len).collect::<Vec<_>>();
 
     // the set of index -> value mappings for the next bucket to be
@@ -111,7 +111,7 @@ fn try_phf_table(
                     // to avoid collisions.
                     let idx = (displace(h.f1, h.f2, d1, d2) % table_len as u32) as usize;
 
-                    if map[idx] != NOVAL || try_map[idx] == generation {
+                    if map[idx] != NO_VAL || try_map[idx] == generation {
                         // nope, this one is taken, so this pair of
                         // displacements doesn't work.
                         continue 'next_disp;

--- a/generator/src/phf.rs
+++ b/generator/src/phf.rs
@@ -144,15 +144,18 @@ pub fn create_phf(
     lambda: usize,
     max_tries: usize,
 ) -> (u64, Vec<(u32, u32)>, Vec<char>) {
+    #[cfg(feature = "timing")]
+    use std::time::Instant;
+
     let mut rng = StdRng::seed_from_u64(0xf0f0f0f0);
     #[cfg(feature = "timing")]
-    let start = time::Instant::now();
+    let start = Instant::now();
 
     for i in 0..(max_tries) {
         #[cfg(feature = "timing")]
-        let my_start = time::Instant::now();
+        let my_start = Instant::now();
         #[cfg(feature = "timing")]
-        println!("PHF #{}: starting {:.2}", i, my_start - start);
+        println!("PHF #{}: starting {:.2?}", i, my_start - start);
         #[cfg(not(feature = "timing"))]
         println!("PHF #{}", i);
 
@@ -160,9 +163,9 @@ pub fn create_phf(
         if let Some((disp, map)) = try_phf_table(data, lambda, seed, &mut rng) {
             #[cfg(feature = "timing")]
             println!(
-                "PHF took: total {:.2} s, successive {:.2} s",
+                "PHF took: total {:.2?} s, successive {:.2?} s",
                 start.elapsed(),
-                my_start.elapsed()
+                my_start.elapsed(),
             );
             return (seed, disp, map);
         }

--- a/generator/src/trie.rs
+++ b/generator/src/trie.rs
@@ -57,7 +57,7 @@ impl Trie {
         ret
     }
 
-    pub fn iter(&self) -> Items {
+    pub fn iter(&self) -> Items<'_> {
         Items {
             parents: vec![],
             current: Some(self),
@@ -74,6 +74,7 @@ pub struct Items<'a> {
 
 impl<'a> Iterator for Items<'a> {
     type Item = (usize, Vec<u8>, Option<usize>);
+
     fn next(&mut self) -> Option<(usize, Vec<u8>, Option<usize>)> {
         'outer: loop {
             if let Some(t) = self.current {

--- a/generator/src/trie.rs
+++ b/generator/src/trie.rs
@@ -31,9 +31,9 @@ impl Trie {
             Some(b) => self.get_child(b).set_offset(it, offset),
         }
     }
-    /// insert the value given by the sequence `it`, returning a tuple
-    /// (is this a substring already in the tree, was this exact
-    /// sequence previously inserted).
+
+    /// insert the value given by the sequence `it`, returning a tuple (is this a substring already
+    /// in the tree, was this exact sequence previously inserted).
     pub fn insert<I: Iterator<Item = u8>>(
         &mut self,
         mut it: I,

--- a/generator/src/util.rs
+++ b/generator/src/util.rs
@@ -13,6 +13,7 @@ pub fn smallest_type<I: Iterator<Item = u32>>(x: I) -> usize {
 pub fn smallest_u<I: Iterator<Item = u32>>(x: I) -> String {
     format!("u{}", 8 * smallest_type(x))
 }
+
 pub fn split<'a, 'b>(s: &'a str, splitters: &'b [u8]) -> Split<'a, 'b> {
     Split {
         s,
@@ -28,8 +29,10 @@ pub struct Split<'a, 'b> {
     pending: &'a str,
     done: bool,
 }
+
 impl<'a, 'b> Iterator for Split<'a, 'b> {
     type Item = &'a str;
+
     fn next(&mut self) -> Option<&'a str> {
         if self.done {
             return None;


### PR DESCRIPTION
It's also possible to use `TryInto` to convert `std::time::Duration` to `time::Duration` (this is what I did at first). But given that we're just printing those numbers nothing in the `time` crate is needed anyways and this code doesn't require any `unwrap()`
