### PR TITLE
Ignore `no_std` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "unicode_names2"
 edition = "2018"
 rust-version = "1.63.0"
@@ -30,9 +29,9 @@ members = [".", "generator"]
 
 [features]
 default = []
-
 unstable = []
 no_std = []
+
 generator-timing = ["unicode_names2_generator/timing"]
 
 [dependencies]

--- a/src/jamo.rs
+++ b/src/jamo.rs
@@ -166,6 +166,7 @@ pub fn slice_shift_jongseong(name: &[u8]) -> (Option<u32>, &[u8]) {
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
     use std::prelude::v1::*;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,9 @@
 //! Convert between characters and their standard names.
 //!
-//! This crate provides two functions for mapping from a `char` to the
-//! name given by the Unicode standard (16.0). There are no runtime
-//! requirements so this is usable with only `core` (this requires
-//! specifying the `no_std` cargo feature). The tables are heavily
-//! compressed, but still large (500KB), and still offer efficient
-//! `O(1)` look-ups in both directions (more precisely, `O(length of
-//! name)`).
+//! This crate provides two functions for mapping from a `char` to the name given by the Unicode
+//! standard (16.0). There are no runtime requirements so this crate is usable with only `core`. The
+//! tables are heavily compressed, but still large (500KB), and still offer efficient `O(1)`
+//! look-ups in both directions (more precisely, `O(length of name)`).
 //!
 //! ```rust
 //!     println!("☃ is called {:?}", unicode_names2::name('☃')); // SNOWMAN
@@ -18,15 +15,12 @@
 //!
 //! # Macros
 //!
-//! The associated `unicode_names2_macros` crate provides two macros
-//! for converting at compile-time, giving named literals similar to
-//! Python's `"\N{...}"`.
+//! The associated `unicode_names2_macros` crate provides two macros for converting at compile-time,
+//! giving named literals similar to Python's `"\N{...}"`.
 //!
-//! - `named_char!(name)` takes a single string `name` and creates a
-//!   `char` literal.
-//! - `named!(string)` takes a string and replaces any `\\N{name}`
-//!   sequences with the character with that name. NB. String escape
-//!   sequences cannot be customised, so the extra backslash (or a raw
+//! - `named_char!(name)` takes a single string `name` and creates a `char` literal.
+//! - `named!(string)` takes a string and replaces any `\\N{name}` sequences with the character with
+//!   that name. NB. String escape sequences cannot be customised, so the extra backslash (or a raw
 //!   string) is required, unless you use a raw string.
 //!
 //! ```rust
@@ -67,13 +61,9 @@
 //! [UAX44-LM2]: https://www.unicode.org/reports/tr44/tr44-34.html#UAX44-LM2
 //! [`is_ascii_whitespace`]: char::is_ascii_whitespace
 
-#![cfg_attr(feature = "no_std", no_std)]
-#![cfg_attr(test, feature(test))]
+#![no_std]
 #![deny(missing_docs, unsafe_code)]
-
-#[cfg(all(test, feature = "no_std"))]
-#[macro_use]
-extern crate std;
+#![cfg_attr(test, feature(test))]
 
 use core::{char, fmt};
 use generated::{
@@ -514,11 +504,11 @@ mod tests {
         distributions::{Distribution, Standard},
         prelude::{SeedableRng, StdRng},
     };
-    use std::char;
-    use std::prelude::v1::*;
+
+    extern crate std;
+    use std::{format, prelude::v1::*};
 
     extern crate test;
-
     use test::bench::Bencher;
 
     static DATA: &'static str =
@@ -783,9 +773,4 @@ mod tests {
             }
         })
     }
-}
-
-#[cfg(all(feature = "no_std", not(test)))]
-mod std {
-    pub use core::{clone, fmt, marker};
 }


### PR DESCRIPTION
Firstly, using a `no_std` feature is [problematic](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification) due to Cargo features needing to be additive, as explicitly mentioned in the linked article.
Thankfully, this wasn't a problem a problem in practice, as the `no_std` feature didn't actually disable any functionality of the crate. For that same reason we can just switch to being `no_std` by default, and link to `std` just for tests.
