### PR TITLE
Use binary search for `is_cjk_unified_ideograph`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,8 +110,17 @@ static NORMALISED_CJK_UNIFIED_IDEOGRAPH_PREFIX: &str = "CJKUNIFIEDIDEOGRAPH";
 
 fn is_cjk_unified_ideograph(ch: char) -> bool {
     generated::CJK_IDEOGRAPH_RANGES
-        .iter()
-        .any(|&(lo, hi)| lo <= ch && ch <= hi)
+        .binary_search_by(|&(lo, hi)| {
+            use core::cmp::Ordering::*;
+            if ch < lo {
+                Less
+            } else if ch > hi {
+                Greater
+            } else {
+                Equal
+            }
+        })
+        .is_ok()
 }
 
 /// An iterator over the components of a code point's name. Notably implements `Display`.


### PR DESCRIPTION
`master`:
```
test tests::character_10000    ... bench:      70,942.37 ns/iter (+/- 1,221.94)
test tests::character_basic    ... bench:         125.86 ns/iter (+/- 1.09)
test tests::name_10000_invalid ... bench:      15,708.71 ns/iter (+/- 1,320.14)
test tests::name_all_valid     ... bench:   2,977,226.38 ns/iter (+/- 72,291.58)
test tests::name_basic         ... bench:          33.73 ns/iter (+/- 0.68)
```
`cjk-binarysearch`:
```
test tests::character_10000    ... bench:      36,063.32 ns/iter (+/- 936.48)
test tests::character_basic    ... bench:         108.07 ns/iter (+/- 4.25)
test tests::name_10000_invalid ... bench:      24,873.60 ns/iter (+/- 751.44)
test tests::name_all_valid     ... bench:   1,498,210.65 ns/iter (+/- 38,873.30)
test tests::name_basic         ... bench:          34.27 ns/iter (+/- 0.99)
```