### PR TITLE
Use binary search in `iter_str.rs`

### DIFF
--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -343,6 +343,11 @@ fn write_codepoint_maps(ctxt: &mut Context, codepoint_names: Vec<(char, &str)>) 
     ctxt.write_plain_string("LEXICON", &lexicon_string);
     ctxt.write_debugs("LEXICON_OFFSETS", "u32", &lexicon_offsets);
     ctxt.write_debugs("LEXICON_SHORT_LENGTHS", "u8", &lexicon_short_lengths);
+    w!(
+        ctxt,
+        "pub const LEXICON_ORDERED_LENGTHS_LEN: usize = {};\n",
+        lexicon_ordered_lengths.len()
+    );
     ctxt.write_debugs(
         "LEXICON_ORDERED_LENGTHS",
         "(usize, u8)",

--- a/src/iter_str.rs
+++ b/src/iter_str.rs
@@ -20,7 +20,7 @@ impl IterStr {
     }
 }
 
-static HYPHEN: u8 = 127;
+const HYPHEN: u8 = 127;
 
 impl Iterator for IterStr {
     type Item = &'static str;
@@ -55,9 +55,8 @@ impl Iterator for IterStr {
 
                     // search for the right place: the first one where
                     // the end-point is after our current index.
-                    match LEXICON_ORDERED_LENGTHS.iter().find(|&&(end, _)| idx < end) {
-                        Some(&(_, len)) => len as usize,
-                        None => unreachable!(),
+                    match LEXICON_ORDERED_LENGTHS.binary_search_by_key(&idx, |&(end, _)| end - 1) {
+                        Ok(i) | Err(i) => LEXICON_ORDERED_LENGTHS[i].1 as usize,
                     }
                 };
                 let offset = LEXICON_OFFSETS[idx] as usize;

--- a/src/iter_str.rs
+++ b/src/iter_str.rs
@@ -1,6 +1,6 @@
 use crate::generated::{
-    LEXICON, LEXICON_OFFSETS, LEXICON_ORDERED_LENGTHS, LEXICON_SHORT_LENGTHS, PHRASEBOOK,
-    PHRASEBOOK_SHORT,
+    LEXICON, LEXICON_OFFSETS, LEXICON_ORDERED_LENGTHS, LEXICON_ORDERED_LENGTHS_LEN,
+    LEXICON_SHORT_LENGTHS, PHRASEBOOK, PHRASEBOOK_SHORT,
 };
 
 #[derive(Clone)]
@@ -9,9 +9,11 @@ struct PhrasebookIter {
 }
 
 impl PhrasebookIter {
-    const EMPTY: Self = Self {
-        index: PHRASEBOOK.len() as u32,
-    };
+    fn empty() -> Self {
+        Self {
+            index: PHRASEBOOK.len() as u32,
+        }
+    }
 }
 
 impl Iterator for PhrasebookIter {
@@ -41,8 +43,8 @@ impl IterStr {
 const HYPHEN: u8 = 127;
 
 /// An array where `arr[i]` holds the largest lexicon index with length `i`.
-static LEXICON_ORDERED_LENGTH_INDICES: [u16; LEXICON_ORDERED_LENGTHS.len()] = {
-    let mut arr = [0u16; LEXICON_ORDERED_LENGTHS.len()];
+static LEXICON_ORDERED_LENGTH_INDICES: [u16; LEXICON_ORDERED_LENGTHS_LEN] = {
+    let mut arr = [0u16; LEXICON_ORDERED_LENGTHS_LEN];
 
     let mut prev_len = None;
     let mut i = 0;
@@ -111,7 +113,7 @@ impl Iterator for IterStr {
             let offset = LEXICON_OFFSETS[idx] as usize;
             &LEXICON[offset..offset + length]
         };
-        self.phrasebook = if is_end { PhrasebookIter::EMPTY } else { tmp };
+        self.phrasebook = if is_end { PhrasebookIter::empty() } else { tmp };
         Some(ret)
     }
 }

--- a/src/iter_str.rs
+++ b/src/iter_str.rs
@@ -1,4 +1,4 @@
-use core::{fmt, slice};
+use core::fmt;
 
 use crate::generated::{
     LEXICON, LEXICON_OFFSETS, LEXICON_ORDERED_LENGTHS, LEXICON_SHORT_LENGTHS, PHRASEBOOK,
@@ -6,15 +6,35 @@ use crate::generated::{
 };
 
 #[derive(Clone)]
+struct PhrasebookIter {
+    index: u32,
+}
+
+impl PhrasebookIter {
+    const EMPTY: Self = Self {
+        index: PHRASEBOOK.len() as u32,
+    };
+}
+
+impl Iterator for PhrasebookIter {
+    type Item = u8;
+    fn next(&mut self) -> Option<Self::Item> {
+        let b = *PHRASEBOOK.get(self.index as usize)?;
+        self.index += 1;
+        Some(b)
+    }
+}
+
+#[derive(Clone)]
 pub struct IterStr {
-    phrasebook: slice::Iter<'static, u8>,
+    phrasebook: PhrasebookIter,
     last_was_word: bool,
 }
 
 impl IterStr {
-    pub fn new(start_index: usize) -> IterStr {
+    pub fn new(start_index: u32) -> IterStr {
         IterStr {
-            phrasebook: PHRASEBOOK[start_index..].iter(),
+            phrasebook: PhrasebookIter { index: start_index },
             last_was_word: false,
         }
     }
@@ -26,7 +46,7 @@ impl Iterator for IterStr {
     type Item = &'static str;
     fn next(&mut self) -> Option<&'static str> {
         let mut tmp = self.phrasebook.clone();
-        tmp.next().map(|&raw_b| {
+        tmp.next().map(|raw_b| {
             // the first byte includes if it is the last in this name
             // in the high bit.
             let (is_end, b) = (raw_b & 0b1000_0000 != 0, raw_b & 0b0111_1111);
@@ -51,7 +71,7 @@ impl Iterator for IterStr {
                     // these lengths are hard-coded
                     LEXICON_SHORT_LENGTHS[idx] as usize
                 } else {
-                    idx = (b - PHRASEBOOK_SHORT) as usize * 256 + (*tmp.next().unwrap()) as usize;
+                    idx = (b - PHRASEBOOK_SHORT) as usize * 256 + (tmp.next().unwrap()) as usize;
 
                     // search for the right place: the first one where
                     // the end-point is after our current index.
@@ -62,7 +82,7 @@ impl Iterator for IterStr {
                 let offset = LEXICON_OFFSETS[idx] as usize;
                 &LEXICON[offset..offset + length]
             };
-            self.phrasebook = if is_end { ([]).iter() } else { tmp };
+            self.phrasebook = if is_end { PhrasebookIter::EMPTY } else { tmp };
             ret
         })
     }

--- a/src/iter_str.rs
+++ b/src/iter_str.rs
@@ -42,6 +42,30 @@ impl IterStr {
 
 const HYPHEN: u8 = 127;
 
+/// An array where `arr[i]` holds the largest lexicon index with length `i`.
+static LEXICON_ORDERED_LENGTH_INDICES: [u16; LEXICON_ORDERED_LENGTHS.len()] = {
+    let mut arr = [0u16; LEXICON_ORDERED_LENGTHS.len()];
+
+    let mut prev_len = None;
+    let mut i = 0;
+    while i < LEXICON_ORDERED_LENGTHS.len() {
+        let (end_idx, length) = LEXICON_ORDERED_LENGTHS[i];
+
+        // make sure this is contiguous - that there are no gaps where e.g. there
+        // are words of length 15 and of length 17 but none of length 16.
+        if let Some(prev_len) = prev_len {
+            assert!(length == prev_len + 1);
+        }
+        prev_len = Some(length);
+
+        assert!(end_idx <= u16::MAX as usize);
+        arr[i] = end_idx as u16 - 1;
+        i += 1;
+    }
+
+    arr
+};
+
 impl Iterator for IterStr {
     type Item = &'static str;
     fn next(&mut self) -> Option<&'static str> {
@@ -73,10 +97,16 @@ impl Iterator for IterStr {
                 } else {
                     idx = (b - PHRASEBOOK_SHORT) as usize * 256 + (tmp.next().unwrap()) as usize;
 
-                    // search for the right place: the first one where
-                    // the end-point is after our current index.
-                    match LEXICON_ORDERED_LENGTHS.binary_search_by_key(&idx, |&(end, _)| end - 1) {
-                        Ok(i) | Err(i) => LEXICON_ORDERED_LENGTHS[i].1 as usize,
+                    // The value at each index `i` in the array `LEXICON_ORDERED_LENGTH_INDICES`
+                    // (herein referred to as `arr`) is the largest lexicon index with length `i`.
+                    match LEXICON_ORDERED_LENGTH_INDICES.binary_search(&(idx as u16)) {
+                        // In this case, `idx` is equal to the index at `arr[i]`,
+                        // so `i` is the correct length.
+                        Ok(i) => i,
+                        // `binary_search(idx)` returning `Err(i)` means that `arr[i-1] < idx < arr[i]`.
+                        // Therefore, `idx` is larger than the largest index with length `i - 1`, but
+                        // smaller than the largest index with length `i`, meaning its length is `i`.
+                        Err(i) => i,
                     }
                 };
                 let offset = LEXICON_OFFSETS[idx] as usize;

--- a/src/iter_str.rs
+++ b/src/iter_str.rs
@@ -1,5 +1,3 @@
-use core::fmt;
-
 use crate::generated::{
     LEXICON, LEXICON_OFFSETS, LEXICON_ORDERED_LENGTHS, LEXICON_SHORT_LENGTHS, PHRASEBOOK,
     PHRASEBOOK_SHORT,
@@ -70,60 +68,50 @@ impl Iterator for IterStr {
     type Item = &'static str;
     fn next(&mut self) -> Option<&'static str> {
         let mut tmp = self.phrasebook.clone();
-        tmp.next().map(|raw_b| {
-            // the first byte includes if it is the last in this name
-            // in the high bit.
-            let (is_end, b) = (raw_b & 0b1000_0000 != 0, raw_b & 0b0111_1111);
+        let raw_b = tmp.next()?;
+        // the first byte includes if it is the last in this name
+        // in the high bit.
+        let (is_end, b) = (raw_b & 0b1000_0000 != 0, raw_b & 0b0111_1111);
 
-            let ret = if b == HYPHEN {
-                // have to handle this before the case below, because a -
-                // replaces the space entirely.
-                self.last_was_word = false;
-                "-"
-            } else if self.last_was_word {
-                self.last_was_word = false;
-                // early return, we don't want to update the
-                // phrasebook (i.e. we're pretending we didn't touch
-                // this byte).
-                return " ";
+        let ret = if b == HYPHEN {
+            // have to handle this before the case below, because a -
+            // replaces the space entirely.
+            self.last_was_word = false;
+            "-"
+        } else if self.last_was_word {
+            self.last_was_word = false;
+            // early return, we don't want to update the
+            // phrasebook (i.e. we're pretending we didn't touch
+            // this byte).
+            return Some(" ");
+        } else {
+            self.last_was_word = true;
+
+            let (length, idx) = if b < PHRASEBOOK_SHORT {
+                let idx = b as usize;
+                // these lengths are hard-coded
+                (LEXICON_SHORT_LENGTHS[idx] as usize, idx)
             } else {
-                self.last_was_word = true;
+                let idx = u16::from_be_bytes([b - PHRASEBOOK_SHORT, tmp.next().unwrap()]);
 
-                let idx;
-                let length = if b < PHRASEBOOK_SHORT {
-                    idx = b as usize;
-                    // these lengths are hard-coded
-                    LEXICON_SHORT_LENGTHS[idx] as usize
-                } else {
-                    idx = (b - PHRASEBOOK_SHORT) as usize * 256 + (tmp.next().unwrap()) as usize;
-
-                    // The value at each index `i` in the array `LEXICON_ORDERED_LENGTH_INDICES`
-                    // (herein referred to as `arr`) is the largest lexicon index with length `i`.
-                    match LEXICON_ORDERED_LENGTH_INDICES.binary_search(&(idx as u16)) {
-                        // In this case, `idx` is equal to the index at `arr[i]`,
-                        // so `i` is the correct length.
-                        Ok(i) => i,
-                        // `binary_search(idx)` returning `Err(i)` means that `arr[i-1] < idx < arr[i]`.
-                        // Therefore, `idx` is larger than the largest index with length `i - 1`, but
-                        // smaller than the largest index with length `i`, meaning its length is `i`.
-                        Err(i) => i,
-                    }
+                // The value at each index `i` in the array `LEXICON_ORDERED_LENGTH_INDICES`
+                // (herein referred to as `arr`) is the largest lexicon index with length `i`.
+                let length = match LEXICON_ORDERED_LENGTH_INDICES.binary_search(&idx) {
+                    // In this case, `idx` is equal to the index at `arr[i]`,
+                    // so `i` is the correct length.
+                    Ok(i) => i,
+                    // `binary_search(idx)` returning `Err(i)` means that `arr[i-1] < idx < arr[i]`.
+                    // Therefore, `idx` is larger than the largest index with length `i - 1`, but
+                    // smaller than the largest index with length `i`, meaning its length is `i`.
+                    Err(i) => i,
                 };
-                let offset = LEXICON_OFFSETS[idx] as usize;
-                &LEXICON[offset..offset + length]
-            };
-            self.phrasebook = if is_end { PhrasebookIter::EMPTY } else { tmp };
-            ret
-        })
-    }
-}
 
-impl fmt::Debug for IterStr {
-    fn fmt(&self, fmtr: &mut fmt::Formatter) -> fmt::Result {
-        let printed = self.clone();
-        for s in printed {
-            write!(fmtr, "{}", s)?
-        }
-        Ok(())
+                (length, idx as usize)
+            };
+            let offset = LEXICON_OFFSETS[idx] as usize;
+            &LEXICON[offset..offset + length]
+        };
+        self.phrasebook = if is_end { PhrasebookIter::EMPTY } else { tmp };
+        Some(ret)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,11 +233,7 @@ impl fmt::Debug for Name {
 }
 impl fmt::Display for Name {
     fn fmt(&self, fmtr: &mut fmt::Formatter) -> fmt::Result {
-        let printed = self.clone();
-        for s in printed {
-            write!(fmtr, "{}", s)?
-        }
-        Ok(())
+        self.clone().try_for_each(|s| fmtr.write_str(s))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,7 +301,7 @@ pub fn name(c: char) -> Option<Name> {
         }
     } else {
         Some(Name {
-            data: Name_::Plain(iter_str::IterStr::new(offset as usize)),
+            data: Name_::Plain(iter_str::IterStr::new(offset)),
         })
     }
 }


### PR DESCRIPTION
Now here's a binary search optimization that actually works :)

`master`:
```
test tests::character_10000    ... bench:      70,944.89 ns/iter (+/- 2,209.11)
test tests::character_basic    ... bench:         115.02 ns/iter (+/- 8.42)
test tests::name_10000_invalid ... bench:      15,799.21 ns/iter (+/- 845.37)
test tests::name_all_valid     ... bench:   3,013,806.90 ns/iter (+/- 356,466.35)
test tests::name_basic         ... bench:          35.91 ns/iter (+/- 5.54)
```
`iterstr-binarysearch`:
```
test tests::character_10000    ... bench:      68,645.04 ns/iter (+/- 1,682.04)
test tests::character_basic    ... bench:         110.49 ns/iter (+/- 2.39)
test tests::name_10000_invalid ... bench:      13,913.38 ns/iter (+/- 1,234.39)
test tests::name_all_valid     ... bench:   2,291,953.23 ns/iter (+/- 32,320.10)
test tests::name_basic         ... bench:          22.13 ns/iter (+/- 2.08)
```
Reviewed well commit by commit.