### PR TITLE
Update to phf 0.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         rust:
         - stable
         - beta
-        - 1.63.0
+        - 1.66.0
 
         features:
         - ''

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "unicode_names2"
 edition = "2018"
-rust-version = "1.63.0"
+rust-version = "1.66.0"
 version = "2.0.0"
 authors = [
     "Huon Wilson <dbau.pp@gmail.com>",
@@ -36,7 +36,7 @@ no_std = []
 generator-timing = ["unicode_names2_generator/timing"]
 
 [dependencies]
-phf = { version = "0.11.1", default-features = false }
+phf = { version = "0.13", default-features = false }
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,7 @@ generator-timing = ["unicode_names2_generator/timing"]
 phf = { version = "0.13", default-features = false }
 
 [dev-dependencies]
-rand = "0.8.5"
-rand_xorshift = "0.3.0"
+fastrand = "2.3.0"
 unicode_names2_macros = { path = "unicode_names2_macros", version = ">=0.3, <3.0" }
 
 [build-dependencies]

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -20,5 +20,5 @@ timing = ["time"]
 
 [dependencies]
 time = { version = "0.3", optional = true }
-rand = "0.8.5"
+fastrand = "2.3.0"
 phf_codegen = "0.13"

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "unicode_names2_generator"
 edition = "2018"
-rust-version = "1.63.0"
+rust-version = "1.66.0"
 version = "2.0.0"
 authors = ["Huon Wilson <dbau.pp@gmail.com>"]
 homepage = "https://github.com/progval/unicode_names2"
@@ -21,4 +21,4 @@ timing = ["time"]
 [dependencies]
 time = { version = "0.3", optional = true }
 rand = "0.8.5"
-phf_codegen = "0.11.1"
+phf_codegen = "0.13"

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -482,7 +482,7 @@ pub fn generate_aliases(name_aliases: &'static str, path: &Path) {
     let mut aliases = phf_codegen::Map::new();
     for Alias { code, alias, .. } in get_aliases(name_aliases).into_iter() {
         let formatted = format!("'\\u{{{code}}}'");
-        aliases.entry(alias, &formatted);
+        aliases.entry(alias, formatted);
     }
     let aliases = aliases.build().to_string().replace("(\"", "(b\"");
     writeln!(BufWriter::new(File::create(path).unwrap()), "{aliases}",).unwrap();

--- a/generator/src/phf.rs
+++ b/generator/src/phf.rs
@@ -3,7 +3,7 @@
 //!
 //! Strongly inspired by https://github.com/sfackler/rust-phf
 
-use rand::prelude::{Rng, SeedableRng, SliceRandom, StdRng};
+use fastrand::Rng;
 use std::iter::repeat;
 
 static NOVAL: char = '\0';
@@ -43,7 +43,7 @@ fn try_phf_table(
     values: &[(char, String)],
     lambda: usize,
     seed: u64,
-    rng: &mut StdRng,
+    rng: &mut Rng,
 ) -> Option<(Vec<(u32, u32)>, Vec<char>)> {
     let hashes: Vec<_> = values
         .iter()
@@ -90,8 +90,8 @@ fn try_phf_table(
     // shuffle them.
     let mut d1s = (0..(table_len as u32)).collect::<Vec<_>>();
     let mut d2s = d1s.clone();
-    d1s.shuffle(rng);
-    d2s.shuffle(rng);
+    rng.shuffle(&mut d1s);
+    rng.shuffle(&mut d2s);
 
     // run through each bucket and try to fit the elements into the
     // array by choosing appropriate adjusting factors
@@ -144,7 +144,7 @@ pub fn create_phf(
     lambda: usize,
     max_tries: usize,
 ) -> (u64, Vec<(u32, u32)>, Vec<char>) {
-    let mut rng = StdRng::seed_from_u64(0xf0f0f0f0);
+    let mut rng = Rng::with_seed(0xf0f0f0f0);
     #[cfg(feature = "timing")]
     let start = time::Instant::now();
 
@@ -156,7 +156,7 @@ pub fn create_phf(
         #[cfg(not(feature = "timing"))]
         println!("PHF #{}", i);
 
-        let seed = rng.gen();
+        let seed = rng.u64(..);
         if let Some((disp, map)) = try_phf_table(data, lambda, seed, &mut rng) {
             #[cfg(feature = "timing")]
             println!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,10 +506,7 @@ fn normalise_name(search_name: &str, buf: &mut [u8; LONGEST_NAME_LEN]) -> usize 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::{
-        distributions::{Distribution, Standard},
-        prelude::{SeedableRng, StdRng},
-    };
+    use fastrand::Rng;
     use std::char;
     use std::prelude::v1::*;
 
@@ -725,14 +722,13 @@ mod tests {
     #[bench]
     fn name_10000_invalid(b: &mut Bencher) {
         // be consistent across runs, but avoid sequential/caching.
-        let mut rng = StdRng::seed_from_u64(0x12345678);
-        let chars: Vec<char> = Standard
-            .sample_iter(&mut rng)
-            .take(10000)
+        let mut rng = Rng::with_seed(0x12345678);
+        let chars: Vec<char> = std::iter::repeat_with(|| rng.char(..))
             .filter_map(|c| match c {
                 c if name(c).is_none() => Some(c),
                 _ => None,
             })
+            .take(10000)
             .collect();
 
         b.iter(|| {
@@ -763,13 +759,12 @@ mod tests {
     #[bench]
     fn character_10000(b: &mut Bencher) {
         // be consistent across runs, but avoid sequential/caching.
-        let mut rng = StdRng::seed_from_u64(0x12345678);
+        let mut rng = Rng::with_seed(0x12345678);
 
-        let names: Vec<_> = Standard
-            .sample_iter(&mut rng)
-            .take(10000)
+        let names: Vec<_> = std::iter::repeat_with(|| rng.char(..))
             .filter_map(name)
             .map(|name| name.to_string())
+            .take(10000)
             .collect();
 
         b.iter(|| {


### PR DESCRIPTION
`phf` 0.13 switches to fastrand, so I also switched to that here. PHF has an msrv of 1.66, so I bumped from 1.63 to that. AFAICT the output of phf_codegen is compatible in the case of mismatched unicode_names2/unicode_names2_generator versions - tests passed with generator on phf 0.11 and the root crate on 0.13.